### PR TITLE
Rule tweaks

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 // Rules are grouped by the same sections as http://eslint.org/docs/rules/
 
 const possibleErrors = {
-  // Warn when `console` is used
-  'no-console': 1,
+  // Disallow the use of `console`
+  'no-console': 2,
 
   // No multiline statements that look like separate statements
   'no-unexpected-multiline': 2
@@ -29,7 +29,7 @@ const bestPractices = {
   'no-eval': 2,
 
   // Empty Block Statements
-  'no-empty': 1,
+  'no-empty': 2,
 
   // Do not extend native/builtin objects
   'no-extend-native': 2,
@@ -112,7 +112,7 @@ const stylistic = {
   'key-spacing': 2,
 
   // Warn when `continue` is used
-  'no-continue': 1,
+  'no-continue': 2,
 
   // Disallow `if` as the only statement in an `else` block
   'no-lonely-if': 2,
@@ -177,6 +177,9 @@ const es6 = {
   // Use spaces around arrows
   'arrow-spacing': 2,
 
+  // Require parentheses around arrow-function arguments
+  'arrow-parens': 2,
+
   // Ensure `super()` is used in subclasses
   'constructor-super': 2,
 
@@ -199,7 +202,7 @@ const es6 = {
   'prefer-const': 2,
 
   // Warn when `apply` is used where the spread operator could be
-  'prefer-spread': 1,
+  'prefer-spread': 2,
 
   // Do not use `var`
   'no-var': 2

--- a/index.js
+++ b/index.js
@@ -111,7 +111,7 @@ const stylistic = {
   // Use whitespace after colons in object keys
   'key-spacing': 2,
 
-  // Warn when `continue` is used
+  // Disallow `continue`
   'no-continue': 2,
 
   // Disallow `if` as the only statement in an `else` block
@@ -201,7 +201,7 @@ const es6 = {
   // Use `const` whenever a variable is not modified
   'prefer-const': 2,
 
-  // Warn when `apply` is used where the spread operator could be
+  // Don't use `apply` where the spread operator could be used instead
   'prefer-spread': 2,
 
   // Do not use `var`


### PR DESCRIPTION
- Require parentheses around arrow function arguments. We've mostly standardized
  on this for web code - it's more readable, and harder to confuse with other
  behaviors.
- Move all warnings to errors. We *never* fix warnings, they just serve to make
  the local `make lint` output less readable, and they don't fail builds in CI.
  If there are cases we need `console.log` and friends, we can add one-off
  exceptions using [inline comments](http://eslint.org/docs/user-guide/configuring#disabling-rules-with-inline-comments).